### PR TITLE
fix(docker): update ENTRYPOINT in Dockerfile to use 'bot' module and …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen
 
 # Run the application.
-ENTRYPOINT ["uv", "run", "python", "-m", "bot.main"]
+ENTRYPOINT ["uv", "run", "python", "-m", "bot"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ This template provides clean start to create bot using aiogram.
 5. Create `.venv` with `uv venv --seed`
 6. Activate virtual environment with `source .venv/bin/activate`
 7. Run migrations with `alembic upgrade head`
-8. Run bot with `python -m bot.main`
+8. Run bot with `python -m bot`
+
+## Start with webhook
+1. Set USE_WEBHOOK to True in .env
+2. Update BOT_SECRET_TOKEN
+3. Set API_HOST to your domain
+4. Update ORIGINS in .env
+5. Start bot with `python -m bot`
 
 ## 🍀 For production
 `docker compose -f compose.yml -f compose.prod.yml up --build -d`


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` and `README.md` to update the bot's entry point and add instructions for starting the bot with a webhook.

Updates to bot entry point:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L26-R26): Modified the `ENTRYPOINT` command to run the bot module directly instead of specifying `bot.main`.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R41): Updated the bot run command to `python -m bot` and added a new section with instructions for starting the bot using a webhook.…update README instructions for starting the bot